### PR TITLE
Add Python notebook that fetches biosample `lat_lon` data via NMDC API

### DIFF
--- a/nmdc/.gitignore
+++ b/nmdc/.gitignore
@@ -1,0 +1,1 @@
+/lat_lons_by_biosample_id.csv

--- a/nmdc/README.md
+++ b/nmdc/README.md
@@ -1,0 +1,9 @@
+# NMDC
+
+This directory contains information about retrieving the geographical origin coordinates of biosamples in the NMDC database.
+
+## References
+
+- [Using Python to access the NMDC API](https://docs.microbiomedata.org/runtime/nb/api_access_via_python/)
+- [NMDC Schema documentation page about the `Biosample` schema class](https://microbiomedata.github.io/nmdc-schema/Biosample/)
+- [NMDC Schema documentation page about the `lat_lon` schema slot](https://microbiomedata.github.io/nmdc-schema/lat_lon/)

--- a/nmdc/get_nmdc_biosample_geo_data.ipynb
+++ b/nmdc/get_nmdc_biosample_geo_data.ipynb
@@ -1,0 +1,125 @@
+{
+    "cells": [
+     {
+      "metadata": {},
+      "cell_type": "markdown",
+      "source": [
+       "# Get NMDC Biosample geolocation data\n",
+       "\n",
+       "You can use this notebook to generate a list of the `id` and geographic origin coordinates of each biosample in the NMDC database."
+      ],
+      "id": "d54028d3f8e33bc5"
+     },
+     {
+      "metadata": {},
+      "cell_type": "markdown",
+      "source": "##### Install and import dependencies",
+      "id": "d49f383a69bca91"
+     },
+     {
+      "metadata": {},
+      "cell_type": "code",
+      "source": "%pip install requests",
+      "id": "8d14c681ceb00c05",
+      "outputs": [],
+      "execution_count": null
+     },
+     {
+      "metadata": {},
+      "cell_type": "code",
+      "source": [
+       "import csv\n",
+       "\n",
+       "import requests"
+      ],
+      "id": "91d33e1b394611dd",
+      "outputs": [],
+      "execution_count": null
+     },
+     {
+      "metadata": {},
+      "cell_type": "markdown",
+      "source": [
+       "##### Fetch the `id` and geographical origin coordinates about each biosample\n",
+       "\n",
+       "In this cell, we fetch the `id` and the geographical origin coordinates about each biosample in the NMDC database.\n",
+       "\n",
+       "The NMDC API endpoint we use here only returns up to 2000 biosamples per request. Since the NMDC database contains more than 2000 biosamples, we submit multiple requests to the NMDC API endpoint."
+      ],
+      "id": "4e88bb65c2b50ba2"
+     },
+     {
+      "metadata": {},
+      "cell_type": "code",
+      "source": [
+       "lat_lons_by_biosample_id = dict()\n",
+       "\n",
+       "page_num = 1\n",
+       "while True:\n",
+       "    request_params = dict(per_page=2000, fields=\"lat_lon\", page=page_num)\n",
+       "    response = requests.get(\"https://api.microbiomedata.org/biosamples\", params=request_params)\n",
+       "\n",
+       "    # Collect the `id` and `lat_lon` value of each biosample in the response.\n",
+       "    # Note: Once we have it locally, we can explore it without Internet access.\n",
+       "    response_payload = response.json()\n",
+       "    for biosample in response_payload[\"results\"]:\n",
+       "        biosample_id = biosample[\"id\"]\n",
+       "        biosample_lat_lon = biosample[\"lat_lon\"]\n",
+       "        lat_lons_by_biosample_id[biosample_id] = biosample_lat_lon\n",
+       "\n",
+       "    # If we haven't fetched all the biosamples yet, prepare to fetch the next batch.\n",
+       "    # Note: In the NMDC database, each biosample has a unique `id` value.\n",
+       "    if len(lat_lons_by_biosample_id) < response_payload[\"meta\"][\"count\"]:\n",
+       "        page_num += 1\n",
+       "    else:\n",
+       "        break\n",
+       "\n",
+       "print(f\"Fetched lat_lon data for {len(lat_lons_by_biosample_id)} biosamples\")"
+      ],
+      "id": "9307b4a017df56ea",
+      "outputs": [],
+      "execution_count": null
+     },
+     {
+      "metadata": {},
+      "cell_type": "markdown",
+      "source": [
+       "##### Dump the `id` and geographical origin coordinates to a CSV file\n",
+       "\n",
+       "In this cell, we dump the fetched data to a CSV file. The CSV file will have two columns: `id` and `lat_lon`.\n",
+       "\n",
+       "You can modify this cell to break up the `lat_lon` values based upon your application."
+      ],
+      "id": "b3bbefddfce9b53e"
+     },
+     {
+      "metadata": {},
+      "cell_type": "code",
+      "source": [
+       "OUTFILE_PATH = \"./lat_lons_by_biosample_id.csv\"\n",
+       "\n",
+       "with open(OUTFILE_PATH, \"w\") as file:\n",
+       "    fieldnames = [\"id\", \"lat_lon\"]\n",
+       "    writer = csv.DictWriter(file, fieldnames=fieldnames)\n",
+       "    writer.writeheader()\n",
+       "    for key, value in lat_lons_by_biosample_id.items():\n",
+       "        writer.writerow({\"id\": key, \"lat_lon\": value})\n",
+       "\n",
+       "    print(f\"Dumped data to: {OUTFILE_PATH}\")"
+      ],
+      "id": "989e40f13d35e49",
+      "outputs": [],
+      "execution_count": null
+     }
+    ],
+    "metadata": {
+     "kernelspec": {
+      "name": "python3",
+      "language": "python",
+      "display_name": "Python 3 (ipykernel)"
+     }
+    },
+    "nbformat": 5,
+    "nbformat_minor": 9
+   }
+   


### PR DESCRIPTION
On this branch, I added a top-level folder named `nmdc`. It has three files inside:
- `README.md` - contains an overview of the folder
- `get_nmdc_biosample_geo_data.ipynb` - notebook people can use to generate a CSV file containing the `id` value and `lat_lon` value of every biosample in the NMDC database
- `.gitignore` - tells Git I want it to ignore the CSV file that the notebook generates