### PR TITLE
Add github action to deploy schema documentation

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,0 +1,55 @@
+name: Auto-deployment of bertron schema documentation
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+
+      - name: Install Poetry.
+        uses: snok/install-poetry@v1.3
+
+      - name: Install dependencies.
+        run: poetry install
+
+      # Replace the `0.0.0` placeholder `version` number in various files (per the config in `pyproject.toml`).
+      # Reference: https://github.com/mtkennerly/poetry-dynamic-versioning/blob/master/README.md#command-line-mode
+      - name: Replace placeholder version number
+        run: |
+          poetry self add "poetry-dynamic-versioning[plugin]"
+          poetry dynamic-versioning
+
+      - name: Derive files from sources
+        run: |
+          make squeaky-clean all
+
+      - name: Generate web-based documentation
+        run: |
+          mkdir -p docs
+          touch docs/.nojekyll
+          make gendoc
+
+        # Deploy the docs to GitHub Pages.
+        #
+        # Note: The `make mkd-gh-deploy` command below uses the `mkd-%` target
+        #       defined in `Makefile`. That target's action (i.e. recipe)
+        #       strips off the `mkd-` prefix and passes the rest of the command
+        #       to `$ poetry run mkdocs`, effectively translating the command
+        #       below into `$ poetry run mkdocs gh-deploy`.
+        #
+        # Reference: https://www.mkdocs.org/user-guide/deploying-your-docs/
+        #
+      - name: Deploy web-based documentation to GitHub Pages
+        run: |
+          make mkd-gh-deploy

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,7 +1,8 @@
 name: Auto-deployment of bertron schema documentation
 on:
-  push:
-    branches: [ main ]
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build-docs:


### PR DESCRIPTION
This PR adds a github action to deploy schema documentation.

This PR depends on https://github.com/ber-data/bertron/pull/6