### PR TITLE
Hide spinner once map has finished loading

### DIFF
--- a/docs/map/index.html
+++ b/docs/map/index.html
@@ -434,6 +434,14 @@
           style: "button", // other option is: "bar"
         });
         map.addControl(search);
+
+        // Hide the behind-the-map spinner, now that the map is visible.
+        //
+        // Note: This makes it so that, even if the user pans/zooms the map content
+        //       "out from in front of the spinner," they will not see the spinner.
+        //
+        const mapSpinnerEl = mapEl.querySelector(".spinner");
+        mapSpinnerEl.style.setProperty("display", "none", "important");
       })();
     </script>
   </body>


### PR DESCRIPTION
### Before

Currently, on the `main` branch, the spinner is only _covered by_ the map. If the user zooms the map all the way out and then drags it downward, the spinner can be _uncovered_ (as shown here).

<img width="300" alt="image" src="https://github.com/user-attachments/assets/5bc46603-cac3-4f62-9823-f503f3a840c7" />

### After

On this branch, I updated the web page so that the spinner element is "hidden" (via `display: none`) — as opposed to only being _covered_ — once the map has appeared. The result is shown here.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/a5d135e5-bfad-42fd-a2cc-c2b75618a475" />