### PR TITLE
Implement GHA workflow that builds/pushes container image to GHCR

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -1,0 +1,74 @@
+# GitHub Actions workflow that builds and publishes a container image to GHCR.
+name: Build and push container image to GHCR
+
+on:
+  # Run this workflow whenever a release is published.
+  release:
+    types: [published]
+  # Allow people to trigger the workflow manually from the GitHub UI.
+  # Docs: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch: {}
+
+jobs:
+  # TODO: Once we have tests defined in this repository, add a job here that runs them;
+  #       and update the `build-and-push-image` job to depend on that job passing. That
+  #       way, the container image is only built and pushed if the tests pass.
+  #
+  # TODO: Once we have version management implemented for the Python application,
+  #       add a step that updates the version in the `pyproject.toml` file based
+  #       on the Git tag of the GitHub Release that triggered this workflow run.
+  #
+  build-and-push-image:
+    name: Build and push container image
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out commit  # docs: https://github.com/actions/checkout
+      uses: actions/checkout@v4
+    
+    # Note: These steps are about building and publishing the container image.
+    - name: Authenticate with container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # Use the `docker/metadata-action` action to extract values that can
+      # be incorporated into the tags and labels of the resulting container
+      # image. The step's `id` ("meta") can be used in subsequent steps to
+      # reference the _outputs_ of this step.
+      # Docs: https://github.com/docker/metadata-action
+    - name: Prepare metadata of container image
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/ber-data/bertron-api
+        flavor: latest=auto
+        tags: type=semver,pattern={{version}}
+        # TODO: Add  `title`, `description`, and `vendor` tags.
+        #
+        # References:
+        # - https://github.com/opencontainers/image-spec/blob/main/annotations.md
+        # - https://github.com/docker/metadata-action/blob/master/README.md#tag
+        # - https://github.com/docker/metadata-action/blob/master/README.md#sha
+        labels: |
+          org.opencontainers.image.documentation=https://github.com/ber-data/bertron
+          org.opencontainers.image.url=https://github.com/ber-data/bertron
+          org.opencontainers.image.source=https://github.com/ber-data/bertron
+          org.opencontainers.image.version={{tag}}
+          org.opencontainers.image.revision={{sha}}
+      # Use the `docker/build-push-action` action to build the image described
+      # by the specified Dockerfile. If the build succeeds, push the image to GHCR.
+      # This action uses the `tags` and `labels` parameters to tag and label
+      # the image, respectively, with the _outputs_ from the "meta" step above.
+      # Docs: https://github.com/docker/build-push-action#usage
+    - name: Build and push container image
+      id: push
+      uses: docker/build-push-action@v5
+      with:
+        # Build the "production" target (stage) defined in the `Dockerfile`.
+        context: .
+        file: Dockerfile
+        target: production
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        push: true


### PR DESCRIPTION
On this branch, I implemented a GitHub Actions workflow that—when run—will build the `web` container image (its name will be `bertron-api`) and publish it to the GitHub Container Registry. Once it has been published there, NERSC's Spin platform will be able to pull it from there and spin it up.