### PR TITLE
Update GHA workflow to workaround bug in third-party action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          # Note: We added this `version: "latest"` to work around the following bug in this GHA:
+          #       https://github.com/astral-sh/setup-uv/issues/489
+          version: "latest"
 
       - name: Install the project
         run: uv sync --all-extras --dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,14 @@ jobs:
       - name: Run tests locally
         run: uv run pytest tests
 
-      # Note: This spins up containers running the default services,
-      #       and the services whose profile is "tools".
-      - name: Spin up Docker Compose stack
-        run: docker compose --profile tools up
+      # Note: This spins up containers running the default services.
+      - name: Spin up Docker Compose stack in background
+        run: docker compose up --detach
+
+      # Note: This spins up the "test" container.
+      - name: Spin up `test` container
+        run: docker compose up test
+
+      # Note: This spins everything down.
+      - name: Spin down Docker Compose stack
+        run: docker compose down

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: uv run pytest tests
 
       - name: Run tests in container environment
-        uses: hoverkraft-tech/compose-action@v2.2.0
+        uses: hoverkraft-tech/compose-action@v2.3.0
         env:
           ACTIONS_RUNNER_DEBUG: true
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,7 @@ jobs:
       - name: Run tests locally
         run: uv run pytest tests
 
-      - name: Run tests in container environment
-        uses: hoverkraft-tech/compose-action@v2.3.0
-        env:
-          ACTIONS_RUNNER_DEBUG: true
-        with:
-          compose-file: "docker-compose.yml"
-          services: "test"
+      # Note: This spins up containers running the default services,
+      #       and the services whose profile is "tools".
+      - name: Spin up Docker Compose stack
+        run: docker compose --profile tools up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - ".:/app"
 
   mongo:
-    image: mongo:8.0.12
+    image: mongo:8.0.11
     ports:
       # The environment variable can be specified either via an `.env` file,
       # or by defining it when invoking `docker compose`, like this:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - ".:/app"
 
   mongo:
-    image: mongo:8.0.10
+    image: mongo:8.0.12
     ports:
       # The environment variable can be specified either via an `.env` file,
       # or by defining it when invoking `docker compose`, like this:


### PR DESCRIPTION
On this branch, we updated our "CI" GHA workflow in two ways:
- Add a workaround for a bug in the GHA that installed `uv`
- Removed a third-party GHA that spins up the Docker Compose stack (we'll spin it up manually instead)
- Updated the Mongo container image version