### PR TITLE
Make API version number accessible via HTTP and display on swagger UI

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -34,6 +34,32 @@ jobs:
     - name: Check out commit  # docs: https://github.com/actions/checkout
       uses: actions/checkout@v4
     
+    # Extract the version number from the GitHub release tag and write it into
+    # the `pyproject.toml` file that will be included in the container image.
+    #
+    # References:
+    # - https://jcgoran.github.io/2021/02/07/bash-string-trimming.html#h-string-removal (for stripping leading 'v')
+    # - https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
+    #
+    - name: Derive version identifier from Git tag or commit hash
+      id: extract_version
+      run: |
+        if [ "${{ github.event_name }}" = "release" ]; then
+          VERSION_RAW="${{ github.event.release.tag_name }}"  # e.g. "v1.2.3"
+          VERSION_SANITIZED="${VERSION_RAW#v}"  # strips leading 'v' if present
+        else
+          COMMIT_HASH="${{ github.sha }}"
+          COMMIT_HASH_SHORT=$(echo "${COMMIT_HASH}" | cut -c1-8)  # e.g. "abcd1234"
+          VERSION_SANITIZED="0.dev-${COMMIT_HASH_SHORT}"  # e.g. "0.dev-abcd1234"
+        fi
+        echo "Version: ${VERSION_SANITIZED}"
+        echo "version=${VERSION_SANITIZED}" >> "${GITHUB_OUTPUT}"  # makes it available to subsequent steps
+    - name: Update version in `pyproject.toml`
+      run: |
+        echo "Version: ${{ steps.extract_version.outputs.version }}"
+        sed -i 's/^version = "0.0.0"/version = "${{ steps.extract_version.outputs.version }}"/' ./pyproject.toml
+        cat ./pyproject.toml | grep '^version = '  # sanity check
+    
     # Note: These steps are about building and publishing the container image.
     - name: Authenticate with container registry
       uses: docker/login-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bertron"
-version = "0.1.0"
+# Project version identifier.
+#
+# Note: The GitHub Actions workflow in `.github/workflows/build-and-push-image.yaml`
+#       will replace this version identifier when building a container image. The
+#       replacement will be the name of the Git tag associated with the GitHub Release
+#       whose publishing triggered the GitHub Actions workflow run.
+#
+version = "0.0.0"
 authors = [
   {name = "Chuck Parker", email = "ctparker@lbl.gov"},
 ]

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,10 @@
+# src
+
+## Contents
+
+<!-- TODO: Summarize the contents of the `bertron/` directory. -->
+
+- `bertron/`: (Undocumented)
+- `bertron_client.py`: A Python library client applications can use to access the BERtron API
+- `README.md`: This document
+- `server.py`: The BERtron API

--- a/src/README.md
+++ b/src/README.md
@@ -6,5 +6,6 @@
 
 - `bertron/`: (Undocumented)
 - `bertron_client.py`: A Python library client applications can use to access the BERtron API
+- `lib/`: Library of helper functions, constants, etc.
 - `README.md`: This document
 - `server.py`: The BERtron API

--- a/src/lib/helpers.py
+++ b/src/lib/helpers.py
@@ -1,7 +1,8 @@
 from importlib.metadata import PackageNotFoundError, version
+from typing import Optional
 
 
-def get_package_version(package_name: str) -> str:
+def get_package_version(package_name: str) -> Optional[str]:
     r"""
     Returns the version identifier (e.g., "1.2.3") of the package having the specified name.
     
@@ -9,9 +10,9 @@ def get_package_version(package_name: str) -> str:
         package_name: The name of the package
         
     Returns:
-        The version identifier of the package, or "Unknown" if package not found
+        The version identifier of the package, or `None` if package not found
     """
     try:
         return version(package_name)
     except PackageNotFoundError:
-        return "Unknown"
+        return None

--- a/src/lib/helpers.py
+++ b/src/lib/helpers.py
@@ -1,0 +1,17 @@
+from importlib.metadata import PackageNotFoundError, version
+
+
+def get_package_version(package_name: str) -> str:
+    r"""
+    Returns the version identifier (e.g., "1.2.3") of the package having the specified name.
+    
+    Args:
+        package_name: The name of the package
+        
+    Returns:
+        The version identifier of the package, or "Unknown" if package not found
+    """
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        return "Unknown"

--- a/src/lib/helpers.py
+++ b/src/lib/helpers.py
@@ -5,10 +5,10 @@ from typing import Optional
 def get_package_version(package_name: str) -> Optional[str]:
     r"""
     Returns the version identifier (e.g., "1.2.3") of the package having the specified name.
-    
+
     Args:
         package_name: The name of the package
-        
+
     Returns:
         The version identifier of the package, or `None` if package not found
     """

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, Field
+
+
+class HealthResponse(BaseModel):
+    r"""A response containing system health information."""
+
+    web_server: bool = Field(
+        ...,
+        title="Web server health",
+        description="Whether the web server is up and running",
+    )
+    database: bool = Field(
+        ...,
+        title="Database health",
+        description="Whether the web server can access the database server",
+    )

--- a/src/models.py
+++ b/src/models.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, Field
+from typing import Optional
 
 
 class HealthResponse(BaseModel):
@@ -19,12 +20,12 @@ class HealthResponse(BaseModel):
 class VersionResponse(BaseModel):
     r"""A response containing system version information."""
 
-    api: str = Field(
+    api: Optional[str] = Field(
         ...,
         title="API version",
         description="The version identifier of the API",
     )
-    bertron_schema: str = Field(
+    bertron_schema: Optional[str] = Field(
         ...,
         title="BERtron schema version",
         description="The version identifier of the BERtron schema",

--- a/src/models.py
+++ b/src/models.py
@@ -14,3 +14,18 @@ class HealthResponse(BaseModel):
         title="Database health",
         description="Whether the web server can access the database server",
     )
+
+
+class VersionResponse(BaseModel):
+    r"""A response containing system version information."""
+
+    api: str = Field(
+        ...,
+        title="API version",
+        description="The version identifier of the API",
+    )
+    bertron_schema: str = Field(
+        ...,
+        title="BERtron schema version",
+        description="The version identifier of the BERtron schema",
+    )

--- a/src/server.py
+++ b/src/server.py
@@ -7,6 +7,8 @@ from pydantic import BaseModel, Field
 from schema.datamodel import bertron_schema_pydantic
 import logging
 
+from models import HealthResponse
+
 # Set up logging
 logger = logging.getLogger(__name__)
 
@@ -24,10 +26,10 @@ def get_root():
 
 
 @app.get("/health")
-def get_health():
-    r"""Get API health information."""
+def get_health() -> HealthResponse:
+    r"""Get system health information."""
     is_database_healthy = len(mongo_client.list_database_names()) > 0
-    return {"web_server": "ok", "database": is_database_healthy}
+    return HealthResponse(web_server=True, database=is_database_healthy)
 
 
 @app.get("/bertron")

--- a/src/server.py
+++ b/src/server.py
@@ -1,13 +1,15 @@
+from importlib.metadata import version
+import logging
+from typing import Optional, Dict, Any
+
 from fastapi import FastAPI, HTTPException, Query
-import uvicorn
 from fastapi.responses import RedirectResponse
 from pymongo import MongoClient
-from typing import Optional, Dict, Any
 from pydantic import BaseModel, Field
 from schema.datamodel import bertron_schema_pydantic
-import logging
+import uvicorn
 
-from models import HealthResponse
+from models import HealthResponse, VersionResponse
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -30,6 +32,17 @@ def get_health() -> HealthResponse:
     r"""Get system health information."""
     is_database_healthy = len(mongo_client.list_database_names()) > 0
     return HealthResponse(web_server=True, database=is_database_healthy)
+
+
+@app.get("/version")
+def get_version() -> VersionResponse:
+    r"""Get system version information."""
+    api_package_name = "bertron"
+    bertron_schema_package_name = "bertron-schema"
+    return VersionResponse(
+        api=version(api_package_name),
+        bertron_schema=version(bertron_schema_package_name)
+    )
 
 
 @app.get("/bertron")

--- a/src/server.py
+++ b/src/server.py
@@ -31,7 +31,10 @@ def get_root():
 def get_health() -> HealthResponse:
     r"""Get system health information."""
     is_database_healthy = len(mongo_client.list_database_names()) > 0
-    return HealthResponse(web_server=True, database=is_database_healthy)
+    return HealthResponse(
+        web_server=True,
+        database=is_database_healthy,
+    )
 
 
 @app.get("/version")
@@ -41,7 +44,7 @@ def get_version() -> VersionResponse:
     bertron_schema_package_name = "bertron-schema"
     return VersionResponse(
         api=version(api_package_name),
-        bertron_schema=version(bertron_schema_package_name)
+        bertron_schema=version(bertron_schema_package_name),
     )
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -1,4 +1,3 @@
-from importlib.metadata import version
 import logging
 from typing import Optional, Dict, Any
 
@@ -9,6 +8,7 @@ from pydantic import BaseModel, Field
 from schema.datamodel import bertron_schema_pydantic
 import uvicorn
 
+from lib.helpers import get_package_version
 from models import HealthResponse, VersionResponse
 
 # Set up logging
@@ -43,8 +43,8 @@ def get_version() -> VersionResponse:
     api_package_name = "bertron"
     bertron_schema_package_name = "bertron-schema"
     return VersionResponse(
-        api=version(api_package_name),
-        bertron_schema=version(bertron_schema_package_name),
+        api=get_package_version(api_package_name),
+        bertron_schema=get_package_version(bertron_schema_package_name),
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "bertron"
-version = "0.1.0"
+version = "0.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "bertron-schema" },


### PR DESCRIPTION
On this branch, I update the GitHub Actions workflow that builds the container image, so it gets the Git tag name (if the workflow was triggered by a GitHub Release being published) or the Git commit hash (otherwise), and overwrites the placeholder `"0.0.0"` version number in `pyproject.toml`.

I also added a `/version` API endpoint that reads the value from `pyproject.toml` and returns it to the HTTP client. This, effectively, allows HTTP clients to determine which version of the API they are accessing.

I also updated the existing `/health` API endpoint to use `true`/`false` as its possible field values, instead of one field using `"ok"` and the other field using `true`/`false`. In other words, I standardized the values across fields. I also implemented a Pydantic model named `HealthResponse`, which makes the "schema" of that response visible to users of our Swagger UI page.

Finally, I added a `src/README.md` file that contains one-line descriptions of the contents of the `src/` folder (except for one item, which I'm punting on describing).