### PR TITLE
Display API version number at top of Swagger UI page

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -18,7 +18,11 @@ logger = logging.getLogger(__name__)
 # TODO: Get these values from environment variables instead of hard-coding them.
 mongo_client = MongoClient("mongo:27017", username="admin", password="root")
 
-app = FastAPI()
+app = FastAPI(
+    title="BERtron API",
+    description="[View source](https://github.com/ber-data/bertron/blob/main/src/server.py)",
+    version=get_package_version("bertron"),
+)
 
 
 @app.get("/", include_in_schema=False)


### PR DESCRIPTION
On this branch, I customized the Swagger UI header. Specifically, I made it so the header shows the same package version number as the `/version` endpoint returns, which comes from `pyproject.toml`. I also replaced the default "FastAPI" title with "BERtron API". Finally, I added a description that links to the GitHub repository.