### PR TITLE
Implement Scalar API docs page at `/scalar`

### DIFF
--- a/mongodb/ingest_data.py
+++ b/mongodb/ingest_data.py
@@ -198,7 +198,7 @@ def main():
     parser.add_argument("--db-name", default="bertron", help="MongoDB database name")
     parser.add_argument(
         "--schema-path",
-        default="https://raw.githubusercontent.com/ber-data/bertron-schema/refs/heads/main/src/schema/jsonschema/bertron_schema.json",
+        default="https://raw.githubusercontent.com/ber-data/bertron-schema/96cbe257717d44137440be369a8414d153579926/src/schema/jsonschema/bertron_schema.json",
         help="Path or URL to the BERtron schema JSON file",
     )
     parser.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,11 @@ dependencies = [
   "nmdc-api-utilities>=0.3.9",
   "pydantic-settings>=2.10.1",
   "pymongo>=4.13.1",
+  # Note: We use `scalar-fastapi` to integrate Scalar API documentation with FastAPI.
+  # Note: We use a Git URL to install the `scalar-fastapi` package, because the Scalar
+  #       maintainers have not published recent versions of the package to PyPI yet.
+  # Reference: https://github.com/scalar/scalar/issues/5337#issuecomment-2781011096
+  "scalar-fastapi @ git+https://github.com/scalar/scalar/#subdirectory=integrations/fastapi",
   "uvicorn>=0.34.3",
 ]
 

--- a/src/server.py
+++ b/src/server.py
@@ -4,6 +4,7 @@ from typing import Optional, Dict, Any, Union
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import RedirectResponse
 from pymongo import MongoClient
+from scalar_fastapi import get_scalar_api_reference
 from schema.datamodel.bertron_schema_pydantic import Entity
 import uvicorn
 
@@ -36,6 +37,19 @@ app = FastAPI(
     ),
     version=f"{get_package_version('bertron')}",
 )
+
+
+@app.get("/scalar", include_in_schema=False)
+async def get_scalar_html():
+    r"""
+    Returns the HTML markup for an interactive API docs web page powered by Scalar.
+    
+    Note: This can coexist with FastAPI's built-in Swagger UI page.
+    """
+    return get_scalar_api_reference(
+        openapi_url=app.openapi_url,
+        title="BERtron API",
+    )
 
 
 @app.get("/", include_in_schema=False)

--- a/src/server.py
+++ b/src/server.py
@@ -43,7 +43,7 @@ app = FastAPI(
 async def get_scalar_html():
     r"""
     Returns the HTML markup for an interactive API docs web page powered by Scalar.
-    
+
     Note: This can coexist with FastAPI's built-in Swagger UI page.
     """
     return get_scalar_api_reference(

--- a/uv.lock
+++ b/uv.lock
@@ -115,6 +115,7 @@ dependencies = [
     { name = "nmdc-api-utilities" },
     { name = "pydantic-settings" },
     { name = "pymongo" },
+    { name = "scalar-fastapi" },
     { name = "uvicorn" },
 ]
 
@@ -135,6 +136,7 @@ requires-dist = [
     { name = "nmdc-api-utilities", specifier = ">=0.3.9" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pymongo", specifier = ">=4.13.1" },
+    { name = "scalar-fastapi", git = "https://github.com/scalar/scalar/?subdirectory=integrations%2Ffastapi" },
     { name = "uvicorn", specifier = ">=0.34.3" },
 ]
 
@@ -2396,6 +2398,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/71/26d45a5042bc71db22ddd8252ca9d01e9ca454f230e2996bb04f16d72799/ruff-0.12.7-py3-none-win_amd64.whl", hash = "sha256:9c18f3d707ee9edf89da76131956aba1270c6348bfee8f6c647de841eac7194f", size = 12912365, upload-time = "2025-07-29T22:32:31.517Z" },
     { url = "https://files.pythonhosted.org/packages/4c/9b/0b8aa09817b63e78d94b4977f18b1fcaead3165a5ee49251c5d5c245bb2d/ruff-0.12.7-py3-none-win_arm64.whl", hash = "sha256:dfce05101dbd11833a0776716d5d1578641b7fddb537fe7fa956ab85d1769b69", size = 11982083, upload-time = "2025-07-29T22:32:33.881Z" },
 ]
+
+[[package]]
+name = "scalar-fastapi"
+version = "1.2.3"
+source = { git = "https://github.com/scalar/scalar/?subdirectory=integrations%2Ffastapi#1c82763b50fd5f39323e8babc0877c8886ac2eb1" }
 
 [[package]]
 name = "sentry-sdk"


### PR DESCRIPTION
On this branch, I added an endpoint at `/scalar`, which returns Scalar API docs (which is an alternative to Swagger UI—the two coexist).