### PR TITLE
Pin `bertron-schema` version to `v0.1.0-alpha.10` using Git tag

### DIFF
--- a/mongodb/ingest_data.py
+++ b/mongodb/ingest_data.py
@@ -198,7 +198,7 @@ def main():
     parser.add_argument("--db-name", default="bertron", help="MongoDB database name")
     parser.add_argument(
         "--schema-path",
-        default="https://raw.githubusercontent.com/ber-data/bertron-schema/82498f5f5cbc71ed7abf71b8e2c01d15c003f8d8/src/schema/jsonschema/bertron_schema.json",
+        default="https://raw.githubusercontent.com/ber-data/bertron-schema/v0.1.0-alpha.10",
         help="Path or URL to the BERtron schema JSON file",
     )
     parser.add_argument(

--- a/mongodb/ingest_data.py
+++ b/mongodb/ingest_data.py
@@ -198,7 +198,7 @@ def main():
     parser.add_argument("--db-name", default="bertron", help="MongoDB database name")
     parser.add_argument(
         "--schema-path",
-        default="https://raw.githubusercontent.com/ber-data/bertron-schema/v0.1.0-alpha.10",
+        default="https://raw.githubusercontent.com/ber-data/bertron-schema/v0.1.0-alpha.10/src/schema/jsonschema/bertron_schema.json",
         help="Path or URL to the BERtron schema JSON file",
     )
     parser.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   #       ```
   #       Reference: https://pip.pypa.io/en/stable/topics/vcs-support/
   #
-  "bertron-schema @ git+https://github.com/ber-data/bertron-schema.git@82498f5f5cbc71ed7abf71b8e2c01d15c003f8d8",
+  "bertron-schema @ git+https://github.com/ber-data/bertron-schema.git@v0.1.0-alpha.10",
   # "dtspy @ https://github.com/kbase/dtspy/archive/730828cff3924fc4b2215fe5c1b67bc04aad377f.tar.gz",
   "fastapi[standard]>=0.115.12",
   # `httpx` is a dependency of FastAPI's `TestClient` class, which we use

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10.0, <3.14"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -129,7 +129,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bertron-schema", git = "https://github.com/ber-data/bertron-schema.git?rev=82498f5f5cbc71ed7abf71b8e2c01d15c003f8d8" },
+    { name = "bertron-schema", git = "https://github.com/ber-data/bertron-schema.git?rev=v0.1.0-alpha.10" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jsonschema", specifier = ">=4.0.0" },
@@ -151,7 +151,7 @@ dev = [
 [[package]]
 name = "bertron-schema"
 version = "0.1.0"
-source = { git = "https://github.com/ber-data/bertron-schema.git?rev=82498f5f5cbc71ed7abf71b8e2c01d15c003f8d8#82498f5f5cbc71ed7abf71b8e2c01d15c003f8d8" }
+source = { git = "https://github.com/ber-data/bertron-schema.git?rev=v0.1.0-alpha.10#82498f5f5cbc71ed7abf71b8e2c01d15c003f8d8" }
 dependencies = [
     { name = "linkml" },
     { name = "linkml-runtime" },


### PR DESCRIPTION
I'd like to switch to using the tagged version of the schema. 

As a one time fix I would also like to update the tag "v0.1.0-alpha.10" on this repo to match this commit. 

I realize that this is essentially re-tagging things, but it will allow us to bring all the repos in sync