### PR TITLE
Bump `bertron-schema` tag to `v0.1.0-alpha.11`

### DIFF
--- a/mongodb/ingest_data.py
+++ b/mongodb/ingest_data.py
@@ -198,7 +198,7 @@ def main():
     parser.add_argument("--db-name", default="bertron", help="MongoDB database name")
     parser.add_argument(
         "--schema-path",
-        default="https://raw.githubusercontent.com/ber-data/bertron-schema/v0.1.0-alpha.10/src/schema/jsonschema/bertron_schema.json",
+        default="https://raw.githubusercontent.com/ber-data/bertron-schema/v0.1.0-alpha.11/src/schema/jsonschema/bertron_schema.json",
         help="Path or URL to the BERtron schema JSON file",
     )
     parser.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,14 @@ dependencies = [
   #       "bertron-schema @ git+https://github.com/ber-data/bertron-schema.git"
   #       ```
   #       To depend upon the package built from the contents of a _specific commit_
-  #       in the `bertron-schema` repository, use:
+  #       (identified by either the commit's hash or the name of a tag referencing
+  #       that commit) in the `bertron-schema` repository, use:
   #       ```
-  #       "bertron-schema @ git+https://github.com/ber-data/bertron-schema.git@{COMMIT_HASH}"
+  #       "bertron-schema @ git+https://github.com/ber-data/bertron-schema.git@{COMMIT_HASH__OR__TAG_NAME}"
   #       ```
   #       Reference: https://pip.pypa.io/en/stable/topics/vcs-support/
   #
-  "bertron-schema @ git+https://github.com/ber-data/bertron-schema.git@v0.1.0-alpha.10",
+  "bertron-schema @ git+https://github.com/ber-data/bertron-schema.git@v0.1.0-alpha.11",
   # "dtspy @ https://github.com/kbase/dtspy/archive/730828cff3924fc4b2215fe5c1b67bc04aad377f.tar.gz",
   "fastapi[standard]>=0.115.12",
   # `httpx` is a dependency of FastAPI's `TestClient` class, which we use

--- a/uv.lock
+++ b/uv.lock
@@ -129,7 +129,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bertron-schema", git = "https://github.com/ber-data/bertron-schema.git?rev=v0.1.0-alpha.10" },
+    { name = "bertron-schema", git = "https://github.com/ber-data/bertron-schema.git?rev=v0.1.0-alpha.11" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jsonschema", specifier = ">=4.0.0" },
@@ -151,7 +151,7 @@ dev = [
 [[package]]
 name = "bertron-schema"
 version = "0.1.0"
-source = { git = "https://github.com/ber-data/bertron-schema.git?rev=v0.1.0-alpha.10#82498f5f5cbc71ed7abf71b8e2c01d15c003f8d8" }
+source = { git = "https://github.com/ber-data/bertron-schema.git?rev=v0.1.0-alpha.11#82498f5f5cbc71ed7abf71b8e2c01d15c003f8d8" }
 dependencies = [
     { name = "linkml" },
     { name = "linkml-runtime" },


### PR DESCRIPTION
On this branch, I updated the references to schema versions, to use a newly-created tag: `v0.1.0-alpha.11`. Both the previous tag and this new tag point to the same commit in the `bertron-schema` repository. The changes in this PR are being made in pursuit of having all three repos use the same tag for versions that are compatible with one another.