### PR TITLE
Get `scalar-fastapi` package from PyPI instead of GitHub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,7 @@ dependencies = [
   "pydantic-settings>=2.10.1",
   "pymongo>=4.13.1",
   # Note: We use `scalar-fastapi` to integrate Scalar API documentation with FastAPI.
-  # Note: We use a Git URL to install the `scalar-fastapi` package, because the Scalar
-  #       maintainers have not published recent versions of the package to PyPI yet.
-  # Reference: https://github.com/scalar/scalar/issues/5337#issuecomment-2781011096
-  "scalar-fastapi @ git+https://github.com/scalar/scalar/#subdirectory=integrations/fastapi",
+  "scalar-fastapi >= 1.4.1",
   "uvicorn>=0.34.3",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -136,7 +136,7 @@ requires-dist = [
     { name = "nmdc-api-utilities", specifier = ">=0.3.9" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pymongo", specifier = ">=4.13.1" },
-    { name = "scalar-fastapi", git = "https://github.com/scalar/scalar/?subdirectory=integrations%2Ffastapi" },
+    { name = "scalar-fastapi", specifier = ">=1.4.1" },
     { name = "uvicorn", specifier = ">=0.34.3" },
 ]
 
@@ -2402,8 +2402,12 @@ wheels = [
 
 [[package]]
 name = "scalar-fastapi"
-version = "1.2.3"
-source = { git = "https://github.com/scalar/scalar/?subdirectory=integrations%2Ffastapi#1c82763b50fd5f39323e8babc0877c8886ac2eb1" }
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/ed/8efedc23b992fbceefa9fd4f895e48766762ec95141d6fd8a05174dc10ec/scalar_fastapi-1.4.1.tar.gz", hash = "sha256:1333350d34ea4718c507afb6d905dce93612d2e9f3decd58166ca5f32f5a0f6e", size = 12677, upload-time = "2025-09-15T19:57:10.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/e1/e062a7e8b1e7f6c4d719d963a3464adc2a7cc6e5593a48f45c058a6315c1/scalar_fastapi-1.4.1-py3-none-any.whl", hash = "sha256:a583e7f0c8a972cb262f103ab832bc8c4e4189259faf048853afefbf37258a41", size = 14526, upload-time = "2025-09-15T19:57:09.826Z" },
+]
 
 [[package]]
 name = "sentry-sdk"


### PR DESCRIPTION
Previously, in `pyproject.toml`, we were telling uv we wanted it to get the `scalar-fastapi` package from GitHub.

https://github.com/ber-data/bertron/blob/2c7eb876d876eb689f1735ffc0c60e098f720e89/pyproject.toml#L48-L52

We did that at a time when the Scalar maintainers were not keeping their PyPI project up to date. Now that they are keeping it up to date, we can get new versions of the package from there instead.

That's the change I made on this branch.

I tested the result by visiting `/scalar` locally and confirming the Scalar API docs still appear.

<img width="628" height="460" alt="image" src="https://github.com/user-attachments/assets/98293d77-81b8-4be0-8d43-d6a2d68406ae" />
