### PR TITLE
Update MONet parsing to be consistent with updated source data format

### DIFF
--- a/docs/map/index.html
+++ b/docs/map/index.html
@@ -336,7 +336,7 @@
         console.debug("Fetching and parsing finished.", { data: monetObjs });
         monetObjs.forEach((obj) => {
           // If the object lacks a `coordinates` field (which the BERtron schema says is possible),
-          // omit it from the map and display a warning on the console.
+          // omit the object from the map and display a warning on the JavaScript console.
           if (!obj.hasOwnProperty("coordinates")) {
             console.warn("Omitting object lacking coordinates:", obj);
             return; // skips to the next iteration

--- a/docs/map/index.html
+++ b/docs/map/index.html
@@ -335,9 +335,21 @@
         const monetMarkers = [];
         console.debug("Fetching and parsing finished.", { data: monetObjs });
         monetObjs.forEach((obj) => {
+          // If the object lacks a `coordinates` field (which the BERtron schema says is possible),
+          // omit it from the map and display a warning on the console.
+          if (!obj.hasOwnProperty("coordinates")) {
+            console.warn("Omitting object lacking coordinates:", obj);
+            return; // skips to the next iteration
+          }
+
+          // If the object lacks an `id` field (which the BERtron schema says is possible),
+          // use a generic value.
+          const identifier = obj.hasOwnProperty("id") ? obj["id"] : "Sample";
+
+          // At this point, we know the object has a `coordinates` field, so we access it.
           const coordinates = obj["coordinates"];
           const latLon = getLatLon(coordinates);
-          const identifier = obj["id"];
+
           const url = obj["uri"];
           const popupHtml = `<div class="vstack gap-3 marker-popup"><img src="./img/emsl-100x100.png" alt="Logo"/><div>EMSL MONet Sample<br/><a href="${url}" target="_blank" title="View project" class="identifier">${identifier}</a></div></div>`;
           const icon = L.icon({

--- a/docs/map/index.html
+++ b/docs/map/index.html
@@ -327,7 +327,7 @@
         });
         console.debug(`Created ${jgiGoldOrgObjs.length} markers.`);
 
-        // Fetch the EMSL MONet JSON (not CSV) file and create a marker for each element of its top-level array.
+        // Fetch the EMSL MONet JSON (not CSV) file and create a marker for each BERtron entity represented within it.
         const monetResponse = await fetch(
           `${baseUrlForData}/emsl/map/monet_samples_schema-9-16-2025.json`,
         );
@@ -335,9 +335,10 @@
         const monetMarkers = [];
         console.debug("Fetching and parsing finished.", { data: monetObjs });
         monetObjs.forEach((obj) => {
-          const latLon = getLatLon(obj);
-          const identifier = `Project: ${obj["proposal_id"]}, Sampling set: ${obj["sampling_set"]}`;
-          const url = `https://sc-data.emsl.pnnl.gov/?projectId=${obj["proposal_id"]}`;
+          const coordinates = obj["coordinates"];
+          const latLon = getLatLon(coordinates);
+          const identifier = obj["id"];
+          const url = obj["uri"];
           const popupHtml = `<div class="vstack gap-3 marker-popup"><img src="./img/emsl-100x100.png" alt="Logo"/><div>EMSL MONet Sample<br/><a href="${url}" target="_blank" title="View project" class="identifier">${identifier}</a></div></div>`;
           const icon = L.icon({
             iconUrl: "./img/emsl-marker.png",


### PR DESCRIPTION
Currently, on the `main` branch, the map web page is not loading (screenshot in #111). That's because the data it is fetching is in a different format than the web page was written to parse (the data is in the new "array of `Entity`s" format, whereas the web page was written to parse the "array of thingies" format the BERtron hackathon members had come up with a few months ago).

On this branch, I updated the web page to parse that data in a way that works with the new format. I expect to do something similar for the other "data sources" (e.g. NMDC, JGI) once their JSON files get updated.

Fixes #111 